### PR TITLE
remove "inout" for type reference, fix for Zeek v7 / Spicy v1.11.0

### DIFF
--- a/analyzer/profinet_io_cm_message.spicy
+++ b/analyzer/profinet_io_cm_message.spicy
@@ -21,7 +21,7 @@ public type Messages = unit {
 
 type ConfigFragmentation = map<string, Message>;
 
-type Message = unit(inout cfgFrag : ConfigFragmentation&) {
+type Message = unit(cfgFrag : ConfigFragmentation&) {
     rpcHeader           : PROFINET_IO_CM_RPC_HEADER::RpcHeader;
     var operationNum    : PROFINET_IO_CM_ENUMS::PnioServicesValue &optional;
     var activityUuid    : string &optional;


### PR DESCRIPTION
fix for `unsupported type for unit parameter 'cfgFrag': type of inout unit parameters must itself be a unit; for other parameter types, use references instead of inout`

explanation from @bbannier on Slack:

> The technical reason this works is that references in Spicy already provide mutable access to the wrapped data (interior mutability). Having an inout on a reference parameter would seem to mean “function can reseat this reference”, but we do not provide that.

Tested after my fix:

```
zkg install https://github.com/mmguero-dev/icsnpp-profinet-io-cm
The following packages will be INSTALLED:
  https://github.com/mmguero-dev/icsnpp-profinet-io-cm (main)

Proceed? [Y/n] y
Running unit tests for "https://github.com/mmguero-dev/icsnpp-profinet-io-cm"
Installing "https://github.com/mmguero-dev/icsnpp-profinet-io-cm"..................................
Installed "https://github.com/mmguero-dev/icsnpp-profinet-io-cm" (main)
Loaded "https://github.com/mmguero-dev/icsnpp-profinet-io-cm"
```