### PR TITLE
change comment format to avoid "discarded extraneous zeekygen comment" warnings

### DIFF
--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -1,12 +1,12 @@
-## main.zeek
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Taegan Williams
-## Contact:  taegan.williams@inl.gov
-##
-## Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
+##! main.zeek
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Taegan Williams
+##! Contact:  taegan.williams@inl.gov
+##!
+##! Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module PROFINET_IO_CM;
 

--- a/analyzer/profinet_io_processing.zeek
+++ b/analyzer/profinet_io_processing.zeek
@@ -1,12 +1,12 @@
-## profinet_io_processing.zeek
-##
-## Zeek Processing. Matches the Types from Spicy (exported .evt) to zeek (types.zeek)
-##
-##
-## Author:   Taegan Williams
-## Contact:  taegan.williams@inl.gov
-##
-## Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
+##! profinet_io_processing.zeek
+##!
+##! Zeek Processing. Matches the Types from Spicy (exported .evt) to zeek (types.zeek)
+##!
+##!
+##! Author:   Taegan Williams
+##! Contact:  taegan.williams@inl.gov
+##!
+##! Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module PROFINET_IO_CM;
 

--- a/analyzer/types.zeek
+++ b/analyzer/types.zeek
@@ -1,12 +1,12 @@
-## types.zeek
-##
-## Zeek records and field types
-##
-##
-## Author:   Taegan Williams
-## Contact:  taegan.williams@inl.gov
-##
-## Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
+##! types.zeek
+##!
+##! Zeek records and field types
+##!
+##!
+##! Author:   Taegan Williams
+##! Contact:  taegan.williams@inl.gov
+##!
+##! Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module PROFINET_IO_CM;
 

--- a/analyzer/zeekEnums.zeek
+++ b/analyzer/zeekEnums.zeek
@@ -1,12 +1,12 @@
-## zeekEnums.zeek
-##
-## zeek constants that convert spicy enums to zeek strings
-##
-##
-## Author:   Taegan Williams
-## Contact:  taegan.williams@inl.gov
-##
-## Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
+##! zeekEnums.zeek
+##!
+##! zeek constants that convert spicy enums to zeek strings
+##!
+##!
+##! Author:   Taegan Williams
+##! Contact:  taegan.williams@inl.gov
+##!
+##! Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module PROFINET_IO_CM;
 


### PR DESCRIPTION
Changed some double-pound comments to double-pound-bash comments to avoid 'discarded extraneous zeekygen comment' warning, see [zeekygen/example.zeek](https://github.com/zeek/zeek/blob/master/scripts/zeekygen/example.zeek) for reference.

Every time I run zeek with this script installed, we see something like this warning:

```
warning in ..., line 1: Discarded extraneous Zeekygen comment: Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
```

If you read the file I linked, it talks about the difference between `#`, `##`, and `##!` comments.

This commit changes the `##` comments at the beginning of the file to `##!` comments.