### PR TITLE
Add Zeek 8.0/8.2 compat for strings and fix RNG reuse in c_functions.cc

### DIFF
--- a/analyzer/c_functions.cc
+++ b/analyzer/c_functions.cc
@@ -17,6 +17,30 @@
 
 namespace c_functions
 {
+    // Spicy exports its version in `PROJECT_VERSION_NUMBER`.
+    // hilti::rt::String was introduced in HILTI 1.16 (Zeek 8.2.1); on
+    // earlier versions (e.g. Zeek 8.0.9 / HILTI 1.14.2) it doesn't exist,
+    // so fall back to std::string there.
+    //
+    // Note: unlike std::string, hilti::rt::String on 8.2+ does NOT
+    // publicly expose insert(), substr(), length(), c_str(), or
+    // operator[] -- it privately inherits std::string, exposing only
+    // construction, operator=, str(), the string_view conversion, and
+    // operator+=. So all string manipulation below stays on
+    // std::string internally; SpicyString is only touched at function
+    // parameter/return boundaries.
+#if PROJECT_VERSION_NUMBER >= 11600
+    using SpicyString = hilti::rt::String;
+#else
+    using SpicyString = std::string;
+#endif
+
+    // Convert a SpicyString parameter/result to a std::string we can
+    // freely manipulate.
+    static inline std::string toStdString(const SpicyString& s) {
+        return std::string(std::string_view(s));
+    }
+
     //
     // Utility function used to generate unique id associated with the OpcUA logs.  While
     // this id is NOT part of the OpcUA documented spec, we use it to tie nested log files
@@ -25,13 +49,20 @@ namespace c_functions
     //
     // The implemenation was taken from: https://lowrey.me/guid-generation-in-c-11/
     //
-    std::string generateId() {
+    SpicyString generateId() {
+        // Constructed once (function-static) rather than per-iteration:
+        // random_device is a seed source, not a PRNG, and re-seeding a
+        // fresh generator every iteration is both slow (repeated entropy
+        // syscalls) and risks producing identical bytes if random_device
+        // falls back to a deterministic sequence on a given platform.
+        // Zeek's packet-analysis path is single-threaded, so static
+        // (rather than thread_local) is safe here.
+        static std::random_device rd;
+        static std::mt19937 gen(rd());
+        static std::uniform_int_distribution<> dis(0, 255);
+
         std::stringstream ss;
         for (auto i = 0; i < 9; i++) {
-            // Generate a random char
-            std::random_device rd;
-            std::mt19937 gen(rd());
-            std::uniform_int_distribution<> dis(0, 255);
             const auto rc = dis(gen);
 
             // Hex representaton of random char
@@ -40,10 +71,11 @@ namespace c_functions
             auto hex = hexstream.str();
             ss << (hex.length() < 2 ? '0' + hex : hex);
         }
-        return ss.str();
+        std::string result = ss.str();
+        return {result};
     }
 
-    std::string bytesToHexString(const char* bytes, size_t size) {
+    SpicyString bytesToHexString(const char* bytes, size_t size) {
         std::string hex_string;
         const char* hex_chars = "0123456789ABCDEF";
 
@@ -52,42 +84,42 @@ namespace c_functions
             hex_string += hex_chars[(byte >> 4) & 0xF];
             hex_string += hex_chars[byte & 0xF];
         }
-        return hex_string;
+        return {hex_string};
     }
 
-    std::string bytesToUuid(const hilti::rt::Bytes &data1,const hilti::rt::Bytes &data2,const hilti::rt::Bytes &data3,const hilti::rt::Bytes &vendorIdLow,const hilti::rt::Bytes &vendorIdHigh,const hilti::rt::Bytes &deviceIdLow,const hilti::rt::Bytes &deviceIdHigh,const hilti::rt::Bytes &instanceLow,const hilti::rt::Bytes &instanceHigh,const hilti::rt::Bytes &rpcObjectUUID){
-        std::string result = "";
-        result += bytesToHexString(data1.data(),4);
+    SpicyString bytesToUuid(const hilti::rt::Bytes &data1,const hilti::rt::Bytes &data2,const hilti::rt::Bytes &data3,const hilti::rt::Bytes &vendorIdLow,const hilti::rt::Bytes &vendorIdHigh,const hilti::rt::Bytes &deviceIdLow,const hilti::rt::Bytes &deviceIdHigh,const hilti::rt::Bytes &instanceLow,const hilti::rt::Bytes &instanceHigh,const hilti::rt::Bytes &rpcObjectUUID){
+        std::string result;
+        result += toStdString(bytesToHexString(data1.data(),4));
         result += "-";
-        result += bytesToHexString(data2.data(),2);
+        result += toStdString(bytesToHexString(data2.data(),2));
         result += "-";
-        result += bytesToHexString(data3.data(),2);
+        result += toStdString(bytesToHexString(data3.data(),2));
         result += "-";
-        result += bytesToHexString(vendorIdLow.data(),1);
-        result += bytesToHexString(vendorIdHigh.data(),1);
+        result += toStdString(bytesToHexString(vendorIdLow.data(),1));
+        result += toStdString(bytesToHexString(vendorIdHigh.data(),1));
         result += "-";
-        result += bytesToHexString(deviceIdLow.data(),1);
-        result += bytesToHexString(deviceIdHigh.data(),1);
-        result += bytesToHexString(instanceLow.data(),1);
-        result += bytesToHexString(instanceHigh.data(),1);
-        result += bytesToHexString(rpcObjectUUID.data(),2);
-        return result;
+        result += toStdString(bytesToHexString(deviceIdLow.data(),1));
+        result += toStdString(bytesToHexString(deviceIdHigh.data(),1));
+        result += toStdString(bytesToHexString(instanceLow.data(),1));
+        result += toStdString(bytesToHexString(instanceHigh.data(),1));
+        result += toStdString(bytesToHexString(rpcObjectUUID.data(),2));
+        return {result};
     }
 
-    std::string macAddress(const hilti::rt::Bytes &byte_string) {
-        std::string mac_string = "";
-        mac_string = bytesToHexString(byte_string.data(),6);
+    SpicyString macAddress(const hilti::rt::Bytes &byte_string) {
+        std::string mac_string = toStdString(bytesToHexString(byte_string.data(),6));
         mac_string.insert(2,":");
         mac_string.insert(5,":");
         mac_string.insert(8,":");
         mac_string.insert(11,":");
         mac_string.insert(14,":");
-        return mac_string;
+        return {mac_string};
     }
 
-    int hexToInt(std::string hexString) {
+    int hexToInt(SpicyString hexString) {
+        std::string s = toStdString(hexString);
         int result = 0;
-        for (char c : hexString) {
+        for (char c : s) {
             result *= 16;
             if (c >= '0' && c <= '9') {
                 result += c - '0';
@@ -102,19 +134,19 @@ namespace c_functions
         return result;
     }
 
-    std::string hexToAscii(std::string hexString) {
-        std::string result = "";
-        for (unsigned int i = 0; i < hexString.length(); i += 2) {
-            std::string byteString = hexString.substr(i, 2);
+    SpicyString hexToAscii(SpicyString hexString) {
+        std::string s = toStdString(hexString);
+        std::string result;
+        for (unsigned int i = 0; i < s.length(); i += 2) {
+            std::string byteString = s.substr(i, 2);
             char byte = (char) strtol(byteString.c_str(), NULL, 16);
             result += byte;
         }
-        return result;
+        return {result};
     }
 
-    std::string bytesToString(const hilti::rt::Bytes& byteString) {
-        std::string hexString = "";
-        hexString = bytesToHexString(byteString.data(),byteString.size());
-        return hexToAscii(hexString);
+    SpicyString bytesToString(const hilti::rt::Bytes& byteString) {
+        std::string hexString = toStdString(bytesToHexString(byteString.data(),byteString.size()));
+        return hexToAscii(SpicyString(hexString));
     }
 }


### PR DESCRIPTION
- Add SpicyString alias (hilti::rt::String on Zeek 8.2+/HILTI >=1.16, std::string on earlier versions) since hilti::rt::String does not exist pre-8.2. Applied to generateId, bytesToHexString, bytesToUuid, macAddress, hexToInt, and hexToAscii.
- Keep all string manipulation (insert, substr, length, c_str, iteration) on plain std::string internally, converting to/from SpicyString only at function boundaries via a toStdString() helper. hilti::rt::String on 8.2+ privately inherits std::string and only publicly exposes construction, operator=, str(), the string_view conversion, and operator+= — none of insert/substr/length/c_str/ operator[]/iterators are accessible on it directly, so calling those on a hilti::rt::String would not compile.
- Return via brace-init ({...}) to avoid chaining two user-defined conversions (std::string -> string_view -> String), which copy-init rejects.
- Hoist random_device/mt19937/uniform_int_distribution in generateId() out of the per-byte loop into function-static locals, constructed once instead of on every iteration. Fixes both a perf issue (repeated entropy syscalls) and a correctness risk: random_device may fall back to a deterministic sequence on some platforms, which combined with per-iteration re-seeding could produce identical bytes across the whole ID. Safe as static (not thread_local) since Zeek's packet analysis path is single-threaded.
